### PR TITLE
Support ESM default export

### DIFF
--- a/src/sharding/cluster.js
+++ b/src/sharding/cluster.js
@@ -266,6 +266,7 @@ class Cluster {
 
         let path = `${rootPath}${this.mainFile}`;
         let app = require(path);
+        if (app.default !== undefined) app = app.default;
         if (app.prototype instanceof Base) {
             this.app = new app({ bot: bot, clusterID: this.clusterID, ipc: this.ipc });
             this.app.launch();


### PR DESCRIPTION
Right now for ESM, users need to do `export = Bot`, this seems counterintuitive with the standard TypeScript codebase as they are not using `export default Bot`. Using `export = Bot` can also have unintended side effects for people using ESM. This PR should remove the need for people to explicitly not use the default export.