### PR TITLE
Remove Debug Code

### DIFF
--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -73,7 +73,7 @@ class ClusterManager extends EventEmitter {
 
         if (this.token) {
             this.eris = new Eris(token);
-            this.launch(false);
+            this.launch();
         } else {
             throw new Error("No token provided");
         }
@@ -165,7 +165,7 @@ class ClusterManager extends EventEmitter {
      * 
      * @memberof ClusterManager
      */
-    launch(test) {
+    launch() {
         if (master.isMaster) {
             process.on("uncaughtException", err => {
                 logger.error("Cluster Manager", err.stack);


### PR DESCRIPTION
The function `ClusterManager#launch()` accepts value `test`, which isn't referenced anywhere in the function. 
When `launch()` is called, it is also passed value `false`.

Just thought I would remove that, because it doesn't do anything, passes a extra value, and makes code more confusing (I spent forever trying to figure out why launch was being passed `false`, and what `test` did).