### PR TITLE
Fixed issue with stats not properly updating

### DIFF
--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -109,7 +109,7 @@ class ClusterManager extends EventEmitter {
      * @memberof ClusterManager
      */
     executeStats(clusters, start) {
-        const clusterToRequest = clusters.filter(c => c[1].state === 'online')[start];
+        const clusterToRequest = clusters.filter(c => c[1].isConnected())[start];
         if (clusterToRequest) {
             let c = clusterToRequest[1];
 


### PR DESCRIPTION
As per the [Node.js docs](https://nodejs.org/api/cluster.html#cluster_class_worker), the `Worker` class does not contain a property named "state". Therefore, the current check will not work as intended. This fixes the issue by replacing the check with a call to `Worker.isConnected()`.