### PR TITLE
Stuck clusters prevent queue progression

### DIFF
--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -350,6 +350,10 @@ class ClusterManager extends EventEmitter {
         });
 
         master.on('exit', (worker, code, signal) => {
+            if (this.queue.queue.length > 0) {
+				this.queue.queue = this.queue.queue.filter((i) => i.value.id !== this.workers.get(worker.id));
+			}
+            
             this.restartCluster(worker, code, signal);
         });
 


### PR DESCRIPTION
### Problem
If a cluster crashes while in the restarting/starting state, the cluster is never removed from the queue. As long as the cluster is in the queue non of the exit queue elements added after it will be executed therefore stalling the queue.

### Solution
Clear any queued elements from the cluster that triggered the "exit" event (through there working ID), after it run the normal restart code again.